### PR TITLE
Fixing implicilty unwrapped optional

### DIFF
--- a/NPO Live/Controller/PlayerViewController.swift
+++ b/NPO Live/Controller/PlayerViewController.swift
@@ -17,6 +17,7 @@ class PlayerViewController: AVPlayerViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        if channel == nil { return }
         guard let url = channel.url else { return }
         let playerItem = AVPlayerItem(url: url)
 


### PR DESCRIPTION
UI test was breaking due to "Unexpectedly found nil while unwrapping an Optional value" error.